### PR TITLE
Put reset methods into the traits

### DIFF
--- a/src/LimitOffset.php
+++ b/src/LimitOffset.php
@@ -49,6 +49,13 @@ trait LimitOffset
         return $this;
     }
 
+    public function resetLimit()
+    {
+        $this->limit = null;
+
+        return $this;
+    }
+
     public function hasOffset()
     {
         return $this->offset !== null;
@@ -69,6 +76,13 @@ trait LimitOffset
         }
 
         $this->offset = $offset;
+
+        return $this;
+    }
+
+    public function resetOffset()
+    {
+        $this->offset = null;
 
         return $this;
     }

--- a/src/LimitOffsetInterface.php
+++ b/src/LimitOffsetInterface.php
@@ -32,6 +32,13 @@ interface LimitOffsetInterface
     public function limit($limit);
 
     /**
+     * Reset the limit
+     *
+     * @return $this
+     */
+    public function resetLimit();
+
+    /**
      * Get whether an offset is configured
      *
      * @return bool
@@ -54,4 +61,11 @@ interface LimitOffsetInterface
      * @return $this
      */
     public function offset($offset);
+
+    /**
+     * Reset the offset
+     *
+     * @return $this
+     */
+    public function resetOffset();
 }

--- a/src/OrderBy.php
+++ b/src/OrderBy.php
@@ -48,6 +48,13 @@ trait OrderBy
         return $this;
     }
 
+    public function resetOrderBy()
+    {
+        $this->orderBy = null;
+
+        return $this;
+    }
+
     /**
      * Clone the properties provided by this trait
      *

--- a/src/OrderByInterface.php
+++ b/src/OrderByInterface.php
@@ -41,4 +41,11 @@ interface OrderByInterface
      * @return $this
      */
     public function orderBy($orderBy, $direction = null);
+
+    /**
+     * Reset the ORDER BY part of the query
+     *
+     * @return $this
+     */
+    public function resetOrderBy();
 }

--- a/src/Select.php
+++ b/src/Select.php
@@ -475,30 +475,6 @@ class Select implements CommonTableExpressionInterface, LimitOffsetInterface, Or
     }
 
     /**
-     * Reset the limit of the query
-     *
-     * @return $this
-     */
-    public function resetLimit()
-    {
-        $this->limit = null;
-
-        return $this;
-    }
-
-    /**
-     * Reset the offset of the query
-     *
-     * @return $this
-     */
-    public function resetOffset()
-    {
-        $this->offset = null;
-
-        return $this;
-    }
-
-    /**
      * Reset queries combined with UNION and UNION ALL
      *
      * @return $this

--- a/src/Select.php
+++ b/src/Select.php
@@ -475,18 +475,6 @@ class Select implements CommonTableExpressionInterface, LimitOffsetInterface, Or
     }
 
     /**
-     * Reset the WHERE part of the query
-     *
-     * @return $this
-     */
-    public function resetWhere()
-    {
-        $this->where = null;
-
-        return $this;
-    }
-
-    /**
      * Get the count query
      *
      * @return Select

--- a/src/Select.php
+++ b/src/Select.php
@@ -463,18 +463,6 @@ class Select implements CommonTableExpressionInterface, LimitOffsetInterface, Or
     }
 
     /**
-     * Reset the ORDER BY part of the query
-     *
-     * @return $this
-     */
-    public function resetOrderBy()
-    {
-        $this->orderBy = null;
-
-        return $this;
-    }
-
-    /**
      * Reset queries combined with UNION and UNION ALL
      *
      * @return $this

--- a/src/Where.php
+++ b/src/Where.php
@@ -47,6 +47,13 @@ trait Where
         return $this;
     }
 
+    public function resetWhere()
+    {
+        $this->where = null;
+
+        return $this;
+    }
+
     /**
      * Make $condition an array and build an array like this: [$operator, [$condition]]
      *

--- a/src/WhereInterface.php
+++ b/src/WhereInterface.php
@@ -74,4 +74,11 @@ interface WhereInterface
      * @return $this
      */
     public function orNotWhere($condition, ...$args);
+
+    /**
+     * Reset the WHERE part of the query
+     *
+     * @return $this
+     */
+    public function resetWhere();
 }


### PR DESCRIPTION
This puts the methods `resetWhere`, `resetOffset`, `resetLimit` and `resetOrderBy` in their respective traits. Just like it's already the case with the `CommonTableExpression` trait.