### PR TITLE
QueryBuilder: Don't render empty sets

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -867,7 +867,7 @@ class QueryBuilder
      */
     public function buildUpdateSet(array $set = null, array &$values = [])
     {
-        if ($set === null) {
+        if (empty($set)) {
             return '';
         }
 

--- a/tests/UpdateTest.php
+++ b/tests/UpdateTest.php
@@ -35,7 +35,7 @@ class UpdateTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame(null, $this->query->getTable());
         $this->assertSame([], $this->query->getSet());
-        $this->assertCorrectStatementAndValues('SET ', []);
+        $this->assertCorrectStatementAndValues('', []);
     }
 
     public function testTableSpecification()
@@ -45,7 +45,7 @@ class UpdateTest extends \PHPUnit\Framework\TestCase
         $this->query->table('table');
 
         $this->assertSame(['table'], $this->query->getTable());
-        $this->assertCorrectStatementAndValues('UPDATE table SET ', []);
+        $this->assertCorrectStatementAndValues('UPDATE table', []);
     }
 
     public function testTableSpecificationWithSchema()
@@ -55,7 +55,7 @@ class UpdateTest extends \PHPUnit\Framework\TestCase
         $this->query->table('schema.table');
 
         $this->assertSame(['schema.table'], $this->query->getTable());
-        $this->assertCorrectStatementAndValues('UPDATE schema.table SET ', []);
+        $this->assertCorrectStatementAndValues('UPDATE schema.table', []);
     }
 
     public function testSet()


### PR DESCRIPTION
I need this for #61. I figured to not render empty sets at all as I don't know why we should do so, instead of changing the `assertSql` method to not drop trailing whitespace.