### PR TITLE
Fix that a literal `%` character is not escaped in conditions

### DIFF
--- a/src/Compat/FilterProcessor.php
+++ b/src/Compat/FilterProcessor.php
@@ -79,9 +79,11 @@ class FilterProcessor
             if ($expression === '*') {
                 return ["$column IS " . ($filter instanceof Filter\Like ? 'NOT ' : '') . 'NULL'];
             } elseif ($filter instanceof Filter\Unlike) {
-                return ["($column NOT LIKE ? OR $column IS NULL)" => str_replace('*', '%', $expression)];
+                return [
+                    "($column NOT LIKE ? OR $column IS NULL)" => str_replace(['%', '*'], ['\\%', '%'], $expression)
+                ];
             } else {
-                return ["$column LIKE ?" => str_replace('*', '%', $expression)];
+                return ["$column LIKE ?" => str_replace(['%', '*'], ['\\%', '%'], $expression)];
             }
         } elseif ($filter instanceof Filter\Unequal || $filter instanceof Filter\Unlike) {
             return ["($column != ? OR $column IS NULL)" => $expression];

--- a/tests/FilterProcessorTest.php
+++ b/tests/FilterProcessorTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace ipl\Tests\Sql;
+
+use ipl\Sql\Compat\FilterProcessor;
+use ipl\Stdlib\Filter;
+
+class FilterProcessorTest extends TestCase
+{
+    public function testLikeToSql()
+    {
+        $this->assertSame(
+            ['foo IS NOT NULL'],
+            FilterProcessor::assemblePredicate(Filter::like('foo', '*'))
+        );
+        $this->assertSame(
+            ['foo LIKE ?' => '%bar%'],
+            FilterProcessor::assemblePredicate(Filter::like('foo', '*bar*'))
+        );
+        $this->assertSame(
+            ['foo LIKE ?' => '%\\%%'],
+            FilterProcessor::assemblePredicate(Filter::like('foo', '*%*'))
+        );
+    }
+
+    public function testUnlikeToSql()
+    {
+        $this->assertSame(
+            ['foo IS NULL'],
+            FilterProcessor::assemblePredicate(Filter::unlike('foo', '*'))
+        );
+        $this->assertSame(
+            ['(foo NOT LIKE ? OR foo IS NULL)' => '%bar%'],
+            FilterProcessor::assemblePredicate(Filter::unlike('foo', '*bar*'))
+        );
+        $this->assertSame(
+            ['(foo NOT LIKE ? OR foo IS NULL)' => '%\\%%'],
+            FilterProcessor::assemblePredicate(Filter::unlike('foo', '*%*'))
+        );
+    }
+}


### PR DESCRIPTION
fixes #71