### PR TITLE
FilterProcessor: Fix predicate assembling for `EXISTS` and `NOT EXISTS` operators

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -256,27 +256,7 @@ parameters:
 			path: src/Connection.php
 
 		-
-			message: "#^Parameter \\#1 \\$mode of method PDOStatement\\:\\:setFetchMode\\(\\) expects int, mixed given\\.$#"
-			count: 1
-			path: src/Connection.php
-
-		-
 			message: "#^Parameter \\#1 \\$object_or_class of function method_exists expects object\\|string, PDO\\|null given\\.$#"
-			count: 1
-			path: src/Connection.php
-
-		-
-			message: "#^Parameter \\#2 \\$className of method PDOStatement\\:\\:setFetchMode\\(\\) expects int\\|object\\|string, mixed given\\.$#"
-			count: 1
-			path: src/Connection.php
-
-		-
-			message: "#^Parameter \\#2 \\$values of method ipl\\\\Sql\\\\Connection\\:\\:prepexec\\(\\) expects array\\|string\\|null, mixed given\\.$#"
-			count: 1
-			path: src/Connection.php
-
-		-
-			message: "#^Parameter \\#2 \\$values of method ipl\\\\Sql\\\\Connection\\:\\:yieldPairs\\(\\) expects array\\|null, mixed given\\.$#"
 			count: 1
 			path: src/Connection.php
 

--- a/src/Compat/FilterProcessor.php
+++ b/src/Compat/FilterProcessor.php
@@ -65,7 +65,7 @@ class FilterProcessor
         $column = $filter->getColumn();
         $expression = $filter->getValue();
 
-        if (is_array($expression) || $expression instanceof Select) {
+        if (! empty($column) && (is_array($expression) || $expression instanceof Select)) {
             $nullVerification = true;
             if (is_array($column)) {
                 if (count($column) === 1) {

--- a/tests/FilterProcessorTest.php
+++ b/tests/FilterProcessorTest.php
@@ -3,7 +3,9 @@
 namespace ipl\Tests\Sql;
 
 use ipl\Sql\Compat\FilterProcessor;
+use ipl\Sql\Filter\Exists;
 use ipl\Sql\Filter\In;
+use ipl\Sql\Filter\NotExists;
 use ipl\Sql\Filter\NotIn;
 use ipl\Sql\Select;
 use ipl\Stdlib\Filter;
@@ -91,6 +93,26 @@ class FilterProcessorTest extends TestCase
         $this->assertSame(
             ['( foo, bar ) NOT IN (?)' => $select],
             FilterProcessor::assemblePredicate(new NotIn(['foo', 'bar'], $select))
+        );
+    }
+
+    public function testExistsToSql()
+    {
+        $select = (new Select())->from('oof')->columns('*');
+
+        $this->assertSame(
+            [' EXISTS ?' => $select],
+            FilterProcessor::assemblePredicate(new Exists($select))
+        );
+    }
+
+    public function testNotExistsToSql()
+    {
+        $select = (new Select())->from('oof')->columns('*');
+
+        $this->assertSame(
+            [' NOT EXISTS ?' => $select],
+            FilterProcessor::assemblePredicate(new NotExists($select))
         );
     }
 }


### PR DESCRIPTION
fix #86 