### PR TITLE
TestConnection: Mock essential methods

### DIFF
--- a/src/Test/TestConnection.php
+++ b/src/Test/TestConnection.php
@@ -13,4 +13,38 @@ class TestConnection extends Connection
     {
         $this->adapter = new TestAdapter();
     }
+
+    public function connect()
+    {
+        return $this;
+    }
+
+    public function beginTransaction()
+    {
+        throw new \LogicException('Transactions are not supported by the test connection');
+    }
+
+    public function commitTransaction()
+    {
+        throw new \LogicException('Transactions are not supported by the test connection');
+    }
+
+    public function rollbackTransaction()
+    {
+        throw new \LogicException('Transactions are not supported by the test connection');
+    }
+
+    public function prepexec($stmt, $values = null)
+    {
+        return new class extends \PDOStatement {
+            public function getIterator(): \Iterator
+            {
+                return new \ArrayIterator([]);
+            }
+
+            public function setFetchMode($mode, ...$args)
+            {
+            }
+        };
+    }
 }


### PR DESCRIPTION
So that using it works somewhat. It is still not a mock that's configurable, i.e. it doesn't provide any results, but this is better than being fully unusable.