### PR TITLE
TestConnection: Add return type to setFetchMode

### DIFF
--- a/src/Test/TestConnection.php
+++ b/src/Test/TestConnection.php
@@ -36,15 +36,30 @@ class TestConnection extends Connection
 
     public function prepexec($stmt, $values = null)
     {
-        return new class extends \PDOStatement {
-            public function getIterator(): \Iterator
-            {
-                return new \ArrayIterator([]);
-            }
+        if (PHP_MAJOR_VERSION >= 8) {
+            return new class extends \PDOStatement {
+                public function getIterator(): \Iterator
+                {
+                    return new \ArrayIterator([]);
+                }
 
-            public function setFetchMode($mode, ...$args)
-            {
-            }
-        };
+                public function setFetchMode($mode, ...$args): bool
+                {
+                    return true;
+                }
+            };
+        } else {
+            return new class extends \PDOStatement {
+                public function getIterator(): \Iterator
+                {
+                    return new \ArrayIterator([]);
+                }
+
+                public function setFetchMode($mode, $params = null): bool
+                {
+                    return true;
+                }
+            };
+        }
     }
 }

--- a/tests/TestConnectionTest.php
+++ b/tests/TestConnectionTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ipl\Tests\Sql;
+
+use ipl\Sql\Test\TestConnection;
+
+class TestConnectionTest extends \PHPUnit\Framework\TestCase
+{
+    public function testPrepexec()
+    {
+        $connection = new TestConnection();
+        $stmt = $connection->prepexec('SELECT * FROM foo');
+        $this->assertEmpty(iterator_to_array($stmt));
+        $this->assertTrue($stmt->setFetchMode(\PDO::FETCH_ASSOC));
+    }
+
+    public function testBeginTransaction()
+    {
+        $connection = new TestConnection();
+        $this->expectException(\LogicException::class);
+        $connection->beginTransaction();
+    }
+
+    public function testCommitTransaction()
+    {
+        $connection = new TestConnection();
+        $this->expectException(\LogicException::class);
+        $connection->commitTransaction();
+    }
+
+    public function testRollbackTransaction()
+    {
+        $connection = new TestConnection();
+        $this->expectException(\LogicException::class);
+        $connection->rollbackTransaction();
+    }
+}


### PR DESCRIPTION
Slipped through in #88 as it's not used at all here. Now a test exists which does.