### PR TITLE
Add strict types to `Connection::prepexec()`

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -384,12 +384,12 @@ class Connection implements Quoter
     /**
      * Prepare and execute the given statement
      *
-     * @param Delete|Insert|Select|Update|string $stmt   The SQL statement to prepare and execute
-     * @param string|array                       $values Values to bind to the statement, if any
+     * @param Delete|Insert|Select|Update|string $stmt The SQL statement to prepare and execute
+     * @param string|array|null $values Values to bind to the statement, if any
      *
      * @return PDOStatement
      */
-    public function prepexec($stmt, $values = null)
+    public function prepexec(Delete|Insert|Select|Update|string $stmt, string|array|null $values = null): PDOStatement
     {
         if ($values !== null && ! is_array($values)) {
             $values = [$values];

--- a/src/Test/TestConnection.php
+++ b/src/Test/TestConnection.php
@@ -3,6 +3,11 @@
 namespace ipl\Sql\Test;
 
 use ipl\Sql\Connection;
+use ipl\Sql\Delete;
+use ipl\Sql\Insert;
+use ipl\Sql\Select;
+use ipl\Sql\Update;
+use PDOStatement;
 
 /**
  * Config-less test connection
@@ -34,7 +39,7 @@ class TestConnection extends Connection
         throw new \LogicException('Transactions are not supported by the test connection');
     }
 
-    public function prepexec($stmt, $values = null)
+    public function prepexec(Delete|Insert|Select|Update|string $stmt, string|array|null $values = null): PDOStatement
     {
         if (PHP_MAJOR_VERSION >= 8) {
             return new class extends \PDOStatement {


### PR DESCRIPTION
This PR adds parameter types and return types to method `Connection::prepexec()`.

This change requires an adjustment in the sub-class `Icinga\Module\Reporting\RetryConnection` of the reporting module.