### PR TITLE
Move `TestCase` into the `ipl\Sql\Test` namespace

### DIFF
--- a/src/Test/TestCase.php
+++ b/src/Test/TestCase.php
@@ -1,9 +1,8 @@
 <?php
 
-namespace ipl\Tests\Sql;
+namespace ipl\Sql\Test;
 
 use ipl\Sql\Select;
-use ipl\Sql\Test\SqlAssertions;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -3,6 +3,7 @@
 namespace ipl\Tests\Sql;
 
 use ipl\Sql\Config;
+use ipl\Sql\Test\TestCase;
 
 class ConfigTest extends TestCase
 {

--- a/tests/DeleteTest.php
+++ b/tests/DeleteTest.php
@@ -4,6 +4,7 @@ namespace ipl\Tests\Sql;
 
 use ipl\Sql\Delete;
 use ipl\Sql\QueryBuilder;
+use ipl\Sql\Test\TestCase;
 
 class DeleteTest extends TestCase
 {

--- a/tests/FilterProcessorTest.php
+++ b/tests/FilterProcessorTest.php
@@ -8,6 +8,7 @@ use ipl\Sql\Filter\In;
 use ipl\Sql\Filter\NotExists;
 use ipl\Sql\Filter\NotIn;
 use ipl\Sql\Select;
+use ipl\Sql\Test\TestCase;
 use ipl\Stdlib\Filter;
 
 class FilterProcessorTest extends TestCase

--- a/tests/HavingTest.php
+++ b/tests/HavingTest.php
@@ -4,6 +4,7 @@ namespace ipl\Tests\Sql;
 
 use ipl\Sql\Expression;
 use ipl\Sql\Select;
+use ipl\Sql\Test\TestCase;
 
 class HavingTest extends TestCase
 {

--- a/tests/InsertTest.php
+++ b/tests/InsertTest.php
@@ -5,6 +5,7 @@ namespace ipl\Tests\Sql;
 use ipl\Sql\Expression;
 use ipl\Sql\Insert;
 use ipl\Sql\Select;
+use ipl\Sql\Test\TestCase;
 
 class InsertTest extends TestCase
 {

--- a/tests/Mssql/SelectTest.php
+++ b/tests/Mssql/SelectTest.php
@@ -3,7 +3,7 @@
 namespace ipl\Tests\Sql\Mssql;
 
 use ipl\Sql\Adapter\Mssql;
-use ipl\Tests\Sql\TestCase;
+use ipl\Sql\Test\TestCase;
 
 class SelectTest extends TestCase
 {

--- a/tests/SelectTest.php
+++ b/tests/SelectTest.php
@@ -5,6 +5,7 @@ namespace ipl\Tests\Sql;
 use ipl\Sql\Expression;
 use ipl\Sql\Select;
 use ipl\Sql\Sql;
+use ipl\Sql\Test\TestCase;
 use UnexpectedValueException;
 
 class SelectTest extends TestCase

--- a/tests/SharedDatabasesTest.php
+++ b/tests/SharedDatabasesTest.php
@@ -5,6 +5,7 @@ namespace ipl\Tests\Sql;
 use ipl\Sql\Connection;
 use ipl\Sql\Select;
 use ipl\Sql\Test\SharedDatabases;
+use ipl\Sql\Test\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
 

--- a/tests/UpdateTest.php
+++ b/tests/UpdateTest.php
@@ -4,6 +4,7 @@ namespace ipl\Tests\Sql;
 
 use ipl\Sql\Expression;
 use ipl\Sql\Select;
+use ipl\Sql\Test\TestCase;
 use ipl\Sql\Update;
 
 class UpdateTest extends TestCase

--- a/tests/WhereTest.php
+++ b/tests/WhereTest.php
@@ -5,6 +5,7 @@ namespace ipl\Tests\Sql;
 use ipl\Sql\Expression;
 use ipl\Sql\Select;
 use ipl\Sql\Sql;
+use ipl\Sql\Test\TestCase;
 
 class WhereTest extends TestCase
 {


### PR DESCRIPTION
`TestCase` was defined in `tests/` which is not part of the distributed
library. Dependents such as `ipl-orm` had to work around this with a vendor
path mapping to `ipl-sql`'s test directory. Moving it into `src/Test/` makes it
a proper member of the `ipl\Sql\Test` testing utilities alongside
`SqlAssertions`, `TestAdapter`, and `TestConnection`.